### PR TITLE
Allow truthy dash-cased props

### DIFF
--- a/src/program/types/JSXAttribute.js
+++ b/src/program/types/JSXAttribute.js
@@ -1,19 +1,19 @@
 import Node from '../Node.js';
 
-const IS_DATA_ATTRIBUTE = /-/;
+const hasDashes = val => /-/.test(val);
+
+const formatKey = key => hasDashes(key) ? `'${key}'` : key;
+
+const formatVal = val => val ? '' : 'true';
 
 export default class JSXAttribute extends Node {
 	transpile ( code, transforms ) {
-		if ( this.value ) {
-			code.overwrite( this.name.end, this.value.start, ': ' );
-		} else {
-			// tag without value
-			code.overwrite( this.name.start, this.name.end, `${this.name.name}: true` );
-		}
+		const { start, name }	= this.name;
 
-		if ( IS_DATA_ATTRIBUTE.test( this.name.name ) ) {
-			code.overwrite( this.name.start, this.name.end, `'${this.name.name}'` );
-		}
+		// Overwrite equals sign if value is present.
+		const end = this.value ? this.value.start : this.name.end;
+
+		code.overwrite( start, end, `${formatKey(name)}: ${formatVal(this.value)}` );
 
 		super.transpile( code, transforms );
 	}

--- a/test/samples/jsx.js
+++ b/test/samples/jsx.js
@@ -224,4 +224,15 @@ module.exports = [
 		`
 	},
 
+	{
+		description: 'handles dash-cased value-less props',
+
+		input: `
+			<Thing data-foo></Thing>
+		`,
+		output: `
+			React.createElement( Thing, { 'data-foo': true })
+		`
+	},
+
 ];


### PR DESCRIPTION
*moved from https://gitlab.com/Rich-Harris/buble/merge_requests/122*

- Add `true` to output if contains dashed and non-value
- Refactor if/else into named functions
- data-attribute -> any dash-cased prop
- Add test