### PR TITLE
fix: `build:browser` failed because of regression in `vlq@0.2.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "acorn-jsx": "^3.0.1",
     "acorn-object-spread": "^1.0.0",
     "chalk": "^1.1.3",
+    "vlq": "0.2.1",
     "magic-string": "^0.14.0",
     "minimist": "^1.2.0",
     "os-homedir": "^1.0.1"


### PR DESCRIPTION
*moved from https://gitlab.com/Rich-Harris/buble/merge_requests/120*