### PR TITLE
Remove unused declarations from Scope.js

### DIFF
--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -1,8 +1,5 @@
 import extractNames from './extractNames.js';
 import reserved from '../utils/reserved.js';
-import CompileError from '../utils/CompileError.js';
-
-const letConst = /^(?:let|const)$/;
 
 export default function Scope ( options ) {
 	options = options || {};


### PR DESCRIPTION
They are unused since abbd217027879adcbd5f6896063f24e24756c2dd.