### PR TITLE
Switch order of parameters for CompileError constructor

### DIFF
--- a/src/program/types/AssignmentExpression.js
+++ b/src/program/types/AssignmentExpression.js
@@ -6,7 +6,7 @@ export default class AssignmentExpression extends Node {
 		if ( this.left.type === 'Identifier' ) {
 			const declaration = this.findScope( false ).findDeclaration( this.left.name );
 			if ( declaration && declaration.kind === 'const' ) {
-				throw new CompileError( this.left, `${this.left.name} is read-only` );
+				throw new CompileError( `${this.left.name} is read-only`, this.left );
 			}
 
 			// special case – https://gitlab.com/Rich-Harris/buble/issues/11

--- a/src/program/types/BreakStatement.js
+++ b/src/program/types/BreakStatement.js
@@ -15,7 +15,7 @@ export default class BreakStatement extends Node {
 
 	transpile ( code ) {
 		if ( this.loop && this.loop.shouldRewriteAsFunction ) {
-			if ( this.label ) throw new CompileError( this, 'Labels are not currently supported in a loop with locally-scoped variables' );
+			if ( this.label ) throw new CompileError( 'Labels are not currently supported in a loop with locally-scoped variables', this );
 			code.overwrite( this.start, this.start + 5, `return 'break'` );
 		}
 	}

--- a/src/program/types/ContinueStatement.js
+++ b/src/program/types/ContinueStatement.js
@@ -6,7 +6,7 @@ export default class ContinueStatement extends Node {
 	transpile ( code ) {
 		const loop = this.findNearest( loopStatement );
 		if ( loop.shouldRewriteAsFunction ) {
-			if ( this.label ) throw new CompileError( this, 'Labels are not currently supported in a loop with locally-scoped variables' );
+			if ( this.label ) throw new CompileError( 'Labels are not currently supported in a loop with locally-scoped variables', this );
 			code.overwrite( this.start, this.start + 8, 'return' );
 		}
 	}

--- a/src/program/types/ExportDefaultDeclaration.js
+++ b/src/program/types/ExportDefaultDeclaration.js
@@ -3,7 +3,7 @@ import CompileError from '../../utils/CompileError.js';
 
 export default class ExportDefaultDeclaration extends Node {
 	initialise ( transforms ) {
-		if ( transforms.moduleExport ) throw new CompileError( this, 'export is not supported' );
+		if ( transforms.moduleExport ) throw new CompileError( 'export is not supported', this );
 		super.initialise( transforms );
 	}
 }

--- a/src/program/types/ExportNamedDeclaration.js
+++ b/src/program/types/ExportNamedDeclaration.js
@@ -3,7 +3,7 @@ import CompileError from '../../utils/CompileError.js';
 
 export default class ExportNamedDeclaration extends Node {
 	initialise ( transforms ) {
-		if ( transforms.moduleExport ) throw new CompileError( this, 'export is not supported' );
+		if ( transforms.moduleExport ) throw new CompileError( 'export is not supported', this );
 		super.initialise( transforms );
 	}
 }

--- a/src/program/types/ForOfStatement.js
+++ b/src/program/types/ForOfStatement.js
@@ -4,7 +4,7 @@ import destructure from '../../utils/destructure.js';
 
 export default class ForOfStatement extends LoopStatement {
 	initialise ( transforms ) {
-		if ( transforms.forOf && !transforms.dangerousForOf ) throw new CompileError( this, 'for...of statements are not supported. Use `transforms: { forOf: false }` to skip transformation and disable this error, or `transforms: { dangerousForOf: true }` if you know what you\'re doing' );
+		if ( transforms.forOf && !transforms.dangerousForOf ) throw new CompileError( 'for...of statements are not supported. Use `transforms: { forOf: false }` to skip transformation and disable this error, or `transforms: { dangerousForOf: true }` if you know what you\'re doing', this );
 		super.initialise( transforms );
 	}
 

--- a/src/program/types/FunctionDeclaration.js
+++ b/src/program/types/FunctionDeclaration.js
@@ -4,7 +4,7 @@ import CompileError from '../../utils/CompileError.js';
 export default class FunctionDeclaration extends Node {
 	initialise ( transforms ) {
 		if ( this.generator && transforms.generator ) {
-			throw new CompileError( this, 'Generators are not supported' );
+			throw new CompileError( 'Generators are not supported', this );
 		}
 
 		this.body.createScope();

--- a/src/program/types/FunctionExpression.js
+++ b/src/program/types/FunctionExpression.js
@@ -4,7 +4,7 @@ import CompileError from '../../utils/CompileError.js';
 export default class FunctionExpression extends Node {
 	initialise ( transforms ) {
 		if ( this.generator && transforms.generator ) {
-			throw new CompileError( this, 'Generators are not supported' );
+			throw new CompileError( 'Generators are not supported', this );
 		}
 
 		this.body.createScope();

--- a/src/program/types/ImportDeclaration.js
+++ b/src/program/types/ImportDeclaration.js
@@ -3,7 +3,7 @@ import CompileError from '../../utils/CompileError.js';
 
 export default class ImportDeclaration extends Node {
 	initialise ( transforms ) {
-		if ( transforms.moduleImport ) throw new CompileError( this, 'import is not supported' );
+		if ( transforms.moduleImport ) throw new CompileError( 'import is not supported', this );
 		super.initialise( transforms );
 	}
 }

--- a/src/program/types/JSXOpeningElement.js
+++ b/src/program/types/JSXOpeningElement.js
@@ -57,7 +57,7 @@ export default class JSXOpeningElement extends Node {
 					before = html ? `',` : ',';
 				} else {
 					if (!this.program.options.objectAssign) {
-						throw new CompileError( this, 'Mixed JSX attributes ending in spread requires specified objectAssign option with \'Object.assign\' or polyfill helper.' );
+						throw new CompileError( 'Mixed JSX attributes ending in spread requires specified objectAssign option with \'Object.assign\' or polyfill helper.', this );
 					}
 					before = html ? `', ${this.program.options.objectAssign}({},` : `, ${this.program.options.objectAssign}({},`;
 					after = ')';

--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -20,7 +20,7 @@ export default class Literal extends Node {
 		if ( this.regex ) {
 			const { pattern, flags } = this.regex;
 
-			if ( transforms.stickyRegExp && /y/.test( flags ) ) throw new CompileError( this, 'Regular expression sticky flag is not supported' );
+			if ( transforms.stickyRegExp && /y/.test( flags ) ) throw new CompileError( 'Regular expression sticky flag is not supported', this );
 			if ( transforms.unicodeRegExp && /u/.test( flags ) ) {
 				code.overwrite( this.start, this.end, `/${rewritePattern( pattern, flags )}/${flags.replace( 'u', '' )}` );
 			}

--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -22,7 +22,7 @@ export default class ObjectExpression extends Node {
 
 		if ( spreadPropertyCount ) {
 			if ( !this.program.options.objectAssign ) {
-				throw new CompileError( this, 'Object spread operator requires specified objectAssign option with \'Object.assign\' or polyfill helper.' );
+				throw new CompileError( 'Object spread operator requires specified objectAssign option with \'Object.assign\' or polyfill helper.', this );
 			}
 			// enclose run of non-spread properties in curlies
 			let i = this.properties.length;

--- a/src/program/types/Super.js
+++ b/src/program/types/Super.js
@@ -11,18 +11,18 @@ export default class Super extends Node {
 			const parentClass = this.findNearest( 'ClassBody' ).parent;
 			this.superClassName = parentClass.superClass && (parentClass.superClass.name || 'superclass');
 
-			if ( !this.superClassName ) throw new CompileError( this, 'super used in base class' );
+			if ( !this.superClassName ) throw new CompileError( 'super used in base class', this );
 
 			this.isCalled = this.parent.type === 'CallExpression' && this === this.parent.callee;
 
 			if ( this.method.kind !== 'constructor' && this.isCalled ) {
-				throw new CompileError( this, 'super() not allowed outside class constructor' );
+				throw new CompileError( 'super() not allowed outside class constructor', this );
 			}
 
 			this.isMember = this.parent.type === 'MemberExpression';
 
 			if ( !this.isCalled && !this.isMember ) {
-				throw new CompileError( this, 'Unexpected use of `super` (expected `super(...)` or `super.*`)' );
+				throw new CompileError( 'Unexpected use of `super` (expected `super(...)` or `super.*`)', this );
 			}
 		}
 

--- a/src/program/types/TaggedTemplateExpression.js
+++ b/src/program/types/TaggedTemplateExpression.js
@@ -4,7 +4,7 @@ import CompileError from '../../utils/CompileError.js';
 export default class TaggedTemplateExpression extends Node {
 	initialise ( transforms ) {
 		if ( transforms.templateString && !transforms.dangerousTaggedTemplateString ) {
-			throw new CompileError( this, 'Tagged template strings are not supported. Use `transforms: { templateString: false }` to skip transformation and disable this error, or `transforms: { dangerousTaggedTemplateString: true }` if you know what you\'re doing' );
+			throw new CompileError( 'Tagged template strings are not supported. Use `transforms: { templateString: false }` to skip transformation and disable this error, or `transforms: { dangerousTaggedTemplateString: true }` if you know what you\'re doing', this );
 		}
 
 		super.initialise( transforms );

--- a/src/program/types/UpdateExpression.js
+++ b/src/program/types/UpdateExpression.js
@@ -6,7 +6,7 @@ export default class UpdateExpression extends Node {
 		if ( this.argument.type === 'Identifier' ) {
 			const declaration = this.findScope( false ).findDeclaration( this.argument.name );
 			if ( declaration && declaration.kind === 'const' ) {
-				throw new CompileError( this, `${this.argument.name} is read-only` );
+				throw new CompileError( `${this.argument.name} is read-only`, this );
 			}
 
 			// special case – https://gitlab.com/Rich-Harris/buble/issues/150

--- a/src/program/types/shared/ModuleDeclaration.js
+++ b/src/program/types/shared/ModuleDeclaration.js
@@ -3,7 +3,7 @@ import CompileError from '../../../utils/CompileError.js';
 
 export default class ModuleDeclaration extends Node {
 	initialise ( transforms ) {
-		if ( transforms.moduleImport ) throw new CompileError( this, 'Modules are not supported' );
+		if ( transforms.moduleImport ) throw new CompileError( 'Modules are not supported', this );
 		super.initialise( transforms );
 	}
 }

--- a/src/utils/CompileError.js
+++ b/src/utils/CompileError.js
@@ -5,10 +5,12 @@ export default class CompileError extends Error {
 	constructor ( message, node ) {
 		super( message );
 
+		this.name = 'CompileError';
+		if ( !node ) { return; }
+
 		const source = node.program.magicString.original;
 		const loc = locate( source, node.start );
 
-		this.name = 'CompileError';
 		this.message = message + ` (${loc.line}:${loc.column})`;
 
 		this.stack = new Error().stack.replace( new RegExp( `.+new ${this.name}.+\\n`, 'm' ), '' );

--- a/src/utils/CompileError.js
+++ b/src/utils/CompileError.js
@@ -2,8 +2,8 @@ import locate from './locate.js';
 import getSnippet from './getSnippet.js';
 
 export default class CompileError extends Error {
-	constructor ( node, message ) {
-		super();
+	constructor ( message, node ) {
+		super( message );
 
 		const source = node.program.magicString.original;
 		const loc = locate( source, node.start );


### PR DESCRIPTION
I've been hitting a problem in a `rollup` (v0.50) + `buble` (v0.16) workflow: Error messages from `buble` are replaced with something more cryptic:

```
TypeError: Cannot read property 'magicString' of undefined
    at new CompileError (/.../node_modules/buble/dist/buble.umd.js:1131:29)
```

As it turns out, [`rollup` is calling the `CompileError` constructor on its own](https://github.com/rollup/rollup/blob/v0.50.0/src/utils/error.js#L8), to decorate `Error`s coming from rollup plugins. But it calls the constructor with only `message` as its first argument, triggering the aforementioned `TypeError`:

![image](https://user-images.githubusercontent.com/1125786/31881397-b37c1b26-b7e3-11e7-8c61-480499c3a8cc.png)

I feel that the easiest workaround is to patch `buble`'s `CompileError` constructor to be more alike the `Error` constructor.