### PR TITLE
Switch to acorn5-object-spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "acorn": "^5.1.2",
     "acorn-jsx": "^3.0.1",
-    "acorn-object-spread": "github:Rich-Harris/acorn-object-spread",
+    "acorn5-object-spread": "^2",
     "magic-string": "^0.14.0",
     "minimist": "^1.2.0",
     "os-homedir": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import * as acorn from 'acorn';
 import acornJsx from 'acorn-jsx/inject';
-import acornObjectSpread from 'acorn-object-spread/inject';
+import acornObjectSpread from 'acorn5-object-spread/inject';
 import Program from './program/Program.js';
 import { features, matrix } from './support.js';
 import getSnippet from './utils/getSnippet.js';

--- a/test/samples/async.js
+++ b/test/samples/async.js
@@ -1,0 +1,12 @@
+module.exports = [
+	{
+		description: 'supports async as property name',
+
+		input: `
+			({async, foo})`,
+
+		output: `
+			({async: async, foo: foo})`,
+	}
+
+];


### PR DESCRIPTION
While [Rich-Harris/acorn-object-spread](/Rich-Harris/acorn-object-spread) somewhat works with acorn 5, it overwrites acorn's current implementation of parsing properties called `async` with something inferior from acorn 4. I added a test case that fails with current master and propose to switch to [my `acorn-object-spread` fork](https://github.com/adrianheine/acorn5-object-spread).