### PR TITLE
Allow aliases in block scope

### DIFF
--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -14,7 +14,7 @@ export default function Scope(options) {
 	this.identifiers = [];
 	this.declarations = Object.create(null);
 	this.references = Object.create(null);
-	this.blockScopedDeclarations = Object.create(null);
+	this.blockScopedDeclarations = this.isBlockScope ? null : Object.create(null);
 	this.aliases = Object.create(null);
 }
 

--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -14,8 +14,8 @@ export default function Scope(options) {
 	this.identifiers = [];
 	this.declarations = Object.create(null);
 	this.references = Object.create(null);
-	this.blockScopedDeclarations = this.isBlockScope ? null : Object.create(null);
-	this.aliases = this.isBlockScope ? null : Object.create(null);
+	this.blockScopedDeclarations = Object.create(null);
+	this.aliases = Object.create(null);
 }
 
 Scope.prototype = {

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -782,5 +782,24 @@ module.exports = [
 			var a = ref.a;
 			var b = ref.b;
 		`
+	},
+
+	{
+		description: 'destructures within block scope',
+
+		input: `
+			if (true) {
+				let [[a, b]] = [[1, 2]];
+			}
+		`,
+
+		output: `
+			if (true) {
+				var ref = [[1, 2]];
+				var ref_0 = ref[0];
+				var a = ref_0[0];
+				var b = ref_0[1];
+			}
+		`
 	}
 ];


### PR DESCRIPTION
I think I'm understanding the logic introduced [here](https://github.com/Rich-Harris/buble/commit/6d9fc0ab0cd769425b026748ffa372d09b1ef35a#diff-3ada2be4c92366e1bf09caeaa19ce9c1R18).

Currently, `blockScopedDeclarations` and `aliases` are set to null within block statements, causing #60. I believe these should be objects in both `block` and `!block` cases.

Includes a minimal test that shows the issue.