### PR TITLE
Fix which scope is used for declaring helpers for computed properties.

### DIFF
--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -16,7 +16,8 @@ export default class BlockStatement extends Node {
 		this.isFunctionBlock = this.parentIsFunction || this.parent.type === 'Root';
 		this.scope = new Scope({
 			block: !this.isFunctionBlock,
-			parent: this.parent.findScope(false)
+			parent: this.parent.findScope(false),
+			declare: id => this.createdDeclarations.push(id)
 		});
 
 		if (this.parentIsFunction) {
@@ -209,12 +210,6 @@ export default class BlockStatement extends Node {
 			if (i === introStatementGenerators.length - 1) suffix = `;\n`;
 			fn(start, prefix, suffix);
 		});
-	}
-
-	declareIdentifier(name) {
-		const id = this.scope.createIdentifier(name);
-		this.createdDeclarations.push(id);
-		return id;
 	}
 
 	transpileParameters(code, transforms, indentation, introStatementGenerators) {

--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -6,6 +6,7 @@ export default function Scope(options) {
 
 	this.parent = options.parent;
 	this.isBlockScope = !!options.block;
+	this.createDeclarationCallback = options.declare;
 
 	let scope = this;
 	while (scope.isBlockScope) scope = scope.parent;
@@ -92,6 +93,12 @@ Scope.prototype = {
 
 		this.aliases[name] = true;
 		return name;
+	},
+
+	createDeclaration(base) {
+		const id = this.createIdentifier(base);
+		this.createDeclarationCallback(id);
+		return id;
 	},
 
 	findDeclaration(name) {

--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -57,17 +57,10 @@ export default class CallExpression extends Node {
 					if (this.callee.object.type === 'Identifier') {
 						context = this.callee.object.name;
 					} else {
-						context = this.findScope(true).createIdentifier('ref');
+						context = this.findScope(true).createDeclaration('ref');
 						const callExpression = this.callee.object;
-						const enclosure = callExpression.findNearest(/Function/);
-						const block = enclosure
-							? enclosure.body.body
-							: callExpression.findNearest(/^Program$/).body;
-						const lastStatementInBlock = block[block.length - 1];
-						const i0 = lastStatementInBlock.getIndentation();
 						code.prependRight(callExpression.start, `(${context} = `);
 						code.appendLeft(callExpression.end, `)`);
-						code.appendLeft(lastStatementInBlock.end, `\n${i0}var ${context};`);
 					}
 				} else {
 					context = 'void 0';

--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -132,7 +132,7 @@ export default class ObjectExpression extends Node {
 					firstSpreadProperty === null ||
 					firstComputedProperty < firstSpreadProperty
 				) {
-					name = this.findLexicalBoundary().declareIdentifier('obj');
+					name = this.findScope(true).createDeclaration('obj');
 
 					code.prependRight(this.start, `( ${name} = `);
 				} else name = null; // We don't actually need this variable
@@ -155,7 +155,7 @@ export default class ObjectExpression extends Node {
 					lastComputedProp = prop;
 
 					if (!name) {
-						name = this.findLexicalBoundary().declareIdentifier('obj');
+						name = this.findScope(true).createDeclaration('obj');
 
 						const propId = name + (prop.computed ? '' : '.');
 						code.appendRight(prop.start, `( ${name} = {}, ${propId}`);

--- a/test/samples/computed-properties.js
+++ b/test/samples/computed-properties.js
@@ -227,9 +227,11 @@ module.exports = [
 			foo => bar({[x - y]: obj});
 		`,
 		output: `
-			var obj$1;
+			!function(foo) {
+				var obj$1;
 
-			!function(foo) { return bar(( obj$1 = {}, obj$1[x - y] = obj, obj$1 )); };
+				return bar(( obj$1 = {}, obj$1[x - y] = obj, obj$1 ));
+			};
 		`
 	},
 
@@ -243,6 +245,19 @@ module.exports = [
 			(function () {
 			var obj, obj$1;
  return ( obj$1 = {}, obj$1[key] = ( obj = {}, obj[key] = val, obj ), obj$1 ) })
+		`
+	},
+
+	{
+		description: 'Puts helper variables in correct scope',
+
+		input: `
+			((x) => {var obj = 2; console.log([{[x]: 1}, obj]);})(3);
+		`,
+		output: `
+			(function (x) {
+			var obj$1;
+var obj = 2; console.log([( obj$1 = {}, obj$1[x] = 1, obj$1 ), obj]);})(3);
 		`
 	}
 ];

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -343,8 +343,9 @@ module.exports = [
 			({ [FirstProp]: one, [SecondProp]: two = 'Too', 3: three, Fore: four } = x);
 		`,
 		output: `
-			var one, two, three, four;
 			var assign;
+
+			var one, two, three, four;
 			((assign = x, one = assign[FirstProp], two = assign[SecondProp], two = two === void 0 ? 'Too' : two, three = assign[3], four = assign.Fore));
 		`
 	},
@@ -468,9 +469,10 @@ module.exports = [
 			console.log(a, b, c, d);
 		`,
 		output: `
+			var assign, array, obj, temp;
+
 			var x = [1, 2, {r: 9}, {s: ["table"]} ];
 			var a, b, c, d;
-			var assign, array, obj, temp;
 			((assign = x, a = assign[0], array = assign.slice(1), b = array[1].r, obj = array[2], c = obj.r, c = c === void 0 ? "nothing" : c, temp = obj.s, temp = temp === void 0 ? "nope" : temp, d = temp[0]));
 			console.log(a, b, c, d);
 		`
@@ -511,6 +513,7 @@ module.exports = [
 			[x, y] = [1, 2];`,
 		output: `
 			var assign;
+
 			(assign = [1, 2], x = assign[0], y = assign[1]);`
 	},
 
@@ -521,6 +524,7 @@ module.exports = [
 			[x = 4, y] = [1, 2];`,
 		output: `
 			var assign;
+
 			(assign = [1, 2], x = assign[0], x = x === void 0 ? 4 : x, y = assign[1]);`
 	},
 
@@ -530,6 +534,7 @@ module.exports = [
 			[[x], y] = [1, 2];`,
 		output: `
 			var assign;
+
 			(assign = [1, 2], x = assign[0][0], y = assign[1]);`
 	},
 
@@ -540,6 +545,7 @@ module.exports = [
 			[[x, z], y] = [1, 2];`,
 		output: `
 			var assign, array;
+
 			(assign = [1, 2], array = assign[0], x = array[0], z = array[1], y = assign[1]);`
 	},
 
@@ -550,6 +556,7 @@ module.exports = [
 			[[x] = [], y] = [1, 2];`,
 		output: `
 			var assign, temp;
+
 			(assign = [1, 2], temp = assign[0], temp = temp === void 0 ? [] : temp, x = temp[0], y = assign[1]);`
 	},
 
@@ -559,6 +566,7 @@ module.exports = [
 			[x, y.z] = [1, 2];`,
 		output: `
 			var assign;
+
 			(assign = [1, 2], x = assign[0], y.z = assign[1]);`
 	},
 
@@ -568,6 +576,7 @@ module.exports = [
 			[x, y.z = 3] = [1, 2];`,
 		output: `
 			var assign, temp;
+
 			(assign = [1, 2], x = assign[0], temp = assign[1], temp = temp === void 0 ? 3 : temp, y.z = temp);`
 	},
 
@@ -577,6 +586,7 @@ module.exports = [
 			({x, y} = {x: 1});`,
 		output: `
 			var assign;
+
 			((assign = {x: 1}, x = assign.x, y = assign.y));`
 	},
 
@@ -587,6 +597,7 @@ module.exports = [
 			({x, y: z} = {x: 1});`,
 		output: `
 			var assign;
+
 			((assign = {x: 1}, x = assign.x, z = assign.y));`
 	},
 
@@ -596,6 +607,7 @@ module.exports = [
 			({x, y: {z}} = {x: 1});`,
 		output: `
 			var assign;
+
 			((assign = {x: 1}, x = assign.x, z = assign.y.z));`
 	},
 
@@ -606,6 +618,7 @@ module.exports = [
 			({x, y = 4} = {x: 1});`,
 		output: `
 			var assign;
+
 			((assign = {x: 1}, x = assign.x, y = assign.y, y = y === void 0 ? 4 : y));`
 	},
 
@@ -615,6 +628,7 @@ module.exports = [
 			({x, y: {z, q}} = {x: 1});`,
 		output: `
 			var assign, obj;
+
 			((assign = {x: 1}, x = assign.x, obj = assign.y, z = obj.z, q = obj.q));`
 	},
 
@@ -624,6 +638,7 @@ module.exports = [
 			({x, y: {z}} = {x: 1});`,
 		output: `
 			var assign;
+
 			((assign = {x: 1}, x = assign.x, z = assign.y.z));`
 	},
 
@@ -635,8 +650,9 @@ module.exports = [
 				baz();
 			}`,
 		output: `
-			foo();
 			var assign;
+
+			foo();
 			if ( bar((assign = [1, 2], x = assign[0], y = assign[1], assign)) ) {
 				baz();
 			}`
@@ -651,6 +667,7 @@ module.exports = [
 		output: `
 			function foo() {
 				var assign;
+
 				(assign = [1, 2], x = assign[0], y = assign[1]);
 			}`
 	},
@@ -728,15 +745,17 @@ module.exports = [
 			console.log( [ a, b ] = c );
 		`,
 		output: `
+			var assign;
+
 			var Point = function Point () {};
 
 			Point.prototype.set = function set ( array ) {
-				var assign;
-					return (assign = array, this.x = assign[0], this.y = assign[1], assign);
+					var assign;
+
+				return (assign = array, this.x = assign[0], this.y = assign[1], assign);
 			};
 
 			var a, b, c = [ 1, 2, 3 ];
-			var assign;
 			console.log( (assign = c, a = assign[0], b = assign[1], assign) );
 		`
 	},
@@ -755,15 +774,17 @@ module.exports = [
 			[ a, b ] = c;
 		`,
 		output: `
+			var assign;
+
 			var Point = function Point () {};
 
 			Point.prototype.set = function set ( array ) {
-				var assign;
-					(assign = array, this.x = assign[0], this.y = assign[1]);
+					var assign;
+
+				(assign = array, this.x = assign[0], this.y = assign[1]);
 			};
 
 			var a, b, c = [ 1, 2, 3 ];
-			var assign;
 			(assign = c, a = assign[0], b = assign[1]);
 		`
 	},

--- a/test/samples/exponentiation-operator.js
+++ b/test/samples/exponentiation-operator.js
@@ -59,7 +59,9 @@ module.exports = [
 			foo.bar.baz **= y;`,
 
 		output: `
-			var object = foo.bar;
+			var object;
+
+			object = foo.bar;
 			object.baz = Math.pow( object.baz, y );`
 	},
 
@@ -82,7 +84,9 @@ module.exports = [
 			foo[ bar() ] **= y;`,
 
 		output: `
-			var property = bar();
+			var property;
+
+			property = bar();
 			foo[property] = Math.pow( foo[property], y );`
 	},
 
@@ -94,8 +98,10 @@ module.exports = [
 			foo[ bar() ][ baz() ] **= y;`,
 
 		output: `
-			var object = foo[ bar() ];
-			var property = baz();
+			var property, object;
+
+			object = foo[ bar() ];
+			property = baz();
 			object[property] = Math.pow( object[property], y );`
 	},
 
@@ -107,7 +113,8 @@ module.exports = [
 			var baz = 1, lolwut = foo[ bar() ][ baz * 2 ] **= y;`,
 
 		output: `
-			var object, property;
+			var property, object;
+
 			var baz = 1, lolwut = ( object = foo[ bar() ], property = baz * 2, object[property] = Math.pow( object[property], y ) );`
 	},
 
@@ -120,6 +127,7 @@ module.exports = [
 
 		output: `
 			var property;
+
 			var baz = 1, lolwut = ( property = bar(), foo[property] = Math.pow( foo[property], y ) );`
 	},
 
@@ -171,6 +179,7 @@ module.exports = [
 		`,
 		output: `
 			var property;
+
 			x=( property = bar(), a[property]=Math.pow( a[property], 2 ) );
 		`
 	}

--- a/test/samples/spread-operator.js
+++ b/test/samples/spread-operator.js
@@ -38,8 +38,9 @@ module.exports = [
 			( foo || bar ).baz( ...values );`,
 
 		output: `
-			(ref = ( foo || bar )).baz.apply( ref, values );
-			var ref;`
+			var ref;
+
+			(ref = ( foo || bar )).baz.apply( ref, values );`
 	},
 
 	{
@@ -51,8 +52,9 @@ module.exports = [
 			}`,
 		output: `
 			function a( args ) {
-				return (ref = this).go.apply( ref, args );
 				var ref;
+
+				return (ref = this).go.apply( ref, args );
 			}`
 	},
 
@@ -84,16 +86,18 @@ module.exports = [
 				while ( len-- ) args[ len ] = arguments[ len ];
 
 				return Domain.run(function () {
-					return (ref = this$1).go.apply(ref, args);
 					var ref;
+
+					return (ref = this$1).go.apply(ref, args);
 				});
 			}
 			function bar(args) {
 				var this$1 = this;
 
 				return Domain.run(function () {
-					return (ref = this$1).go.apply(ref, args);
 					var ref;
+
+					return (ref = this$1).go.apply(ref, args);
 				});
 			}
 			function baz() {
@@ -101,8 +105,9 @@ module.exports = [
 				var this$1 = this;
 
 				return Domain.run(function () {
-					return (ref = this$1).go.apply(ref, arguments$1);
 					var ref;
+
+					return (ref = this$1).go.apply(ref, arguments$1);
 				});
 			}
 		`
@@ -170,11 +175,12 @@ module.exports = [
 			process( result );`,
 
 		output: `
+			var ref$1;
+
 			var result;
 			if ( ref )
 				{ result = (ref$1 = expr()).baz.apply( ref$1, values ); }
-			process( result );
-			var ref$1;`
+			process( result );`
 	},
 
 	{
@@ -190,12 +196,12 @@ module.exports = [
 			}`,
 		output: `
 			function foo() {
+				var ref$1, ref$2;
+
 				stuff();
 				if ( ref )
 					{ return (ref$1 = expr()).baz.apply( ref$1, values ); }
 				return (ref$2 = (up || down)).bar.apply( ref$2, values );
-				var ref$1;
-				var ref$2;
 			}`
 	},
 
@@ -211,12 +217,12 @@ module.exports = [
 			}`,
 		output: `
 			function ref() {
+				var ref, ref$2;
+
 				stuff();
 				if ( ref$1 )
 					{ return (ref = expr()).baz.apply( ref, [ a ].concat( values, [(ref$2 = (up || down)).bar.apply( ref$2, [ c ].concat( values, [d] ) )] ) ); }
 				return other();
-				var ref;
-				var ref$2;
 			}`
 	},
 
@@ -243,9 +249,9 @@ module.exports = [
 				prepare: function prepare() {
 					var i = arguments.length, argsArray = Array(i);
 					while ( i-- ) argsArray[i] = arguments[i];
+					var ref;
 
 					return (ref = this.add).bind.apply(ref, [ this ].concat( argsArray ))
-					var ref;
 				}
 			}`
 	},
@@ -526,8 +532,11 @@ module.exports = [
 		output: `
 			function foo (x) {
 				if ( x )
-					{ return function (ref) { return (ref$1 = (bar || baz)).Test.apply( ref$1, [ ref ].concat( x ) )
-						var ref$1;; }; }
+					{ return function (ref) {
+						var ref$1;
+
+						return (ref$1 = (bar || baz)).Test.apply( ref$1, [ ref ].concat( x ) );
+						}; }
 			}
 		`
 	},
@@ -569,8 +578,11 @@ module.exports = [
 				while ( i-- ) argsArray[i] = arguments[i];
 
 				if ( x )
-					{ return function (ref) { return (ref$1 = (bar || baz)).Test.apply( ref$1, [ ref ].concat( arguments$1 ) )
-						var ref$1;; }; }
+					{ return function (ref) {
+						var ref$1;
+
+						return (ref$1 = (bar || baz)).Test.apply( ref$1, [ ref ].concat( arguments$1 ) );
+						}; }
 			}
 		`
 	}


### PR DESCRIPTION
Closes #57. I also converted `CallExpression` and `AssignmentExpression` to my `Scope#createDeclaration` in two separate commits.