### PR TITLE
Add support for destrcturing catch clause params

### DIFF
--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -155,6 +155,15 @@ export default class BlockStatement extends Node {
 
 		if (/Function/.test(this.parent.type)) {
 			this.transpileParameters(
+				this.parent.params,
+				code,
+				transforms,
+				indentation,
+				introStatementGenerators
+			);
+		} else if ('CatchClause' === this.parent.type) {
+			this.transpileParameters(
+				[this.parent.param],
 				code,
 				transforms,
 				indentation,
@@ -212,9 +221,7 @@ export default class BlockStatement extends Node {
 		});
 	}
 
-	transpileParameters(code, transforms, indentation, introStatementGenerators) {
-		const params = this.parent.params;
-
+	transpileParameters(params, code, transforms, indentation, introStatementGenerators) {
 		params.forEach(param => {
 			if (
 				param.type === 'AssignmentPattern' &&

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -844,5 +844,19 @@ module.exports = [
 				((assign = { x: 3 }, x$1 = assign.x));
 				(assign$1 = [ 3 ], x$1 = assign$1[0]);
 			}`
+	},
+
+	{
+		description: 'destructures try catch parameters',
+
+		input: `
+			try {} catch ({message}) {
+			}`,
+
+		output: `
+			try {} catch (ref) {
+				var message = ref.message;
+
+			}`
 	}
 ];


### PR DESCRIPTION
Fixes #76. With this, all cases in Babel's [babel-plugin-transform-destructuring](https://github.com/babel/babel/blob/f5ef928586f592aa2d8bb60120ae58833d17e0db/packages/babel-plugin-transform-destructuring/src/index.js) are covered.

Changes the check from regex `/Function/` to an explicit list of types to transpile parameters of.

CatchClause uses `param = obj` instead of `params = [obj]`, so the `transpileParameters` function now supports both.