### PR TITLE
Handle string properties after computed properties correctly

### DIFF
--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -161,7 +161,7 @@ export default class ObjectExpression extends Node {
 					} else {
 						const propId =
 							(isSimpleAssignment ? `;\n${i0}${name}` : `, ${name}`) +
-							(prop.computed ? '' : '.');
+							(prop.key.type === 'Literal' || prop.computed ? '' : '.');
 
 						if (moveStart < prop.start) {
 							code.overwrite(moveStart, prop.start, propId);
@@ -175,7 +175,15 @@ export default class ObjectExpression extends Node {
 						while (code.original[c] !== ']') c += 1;
 						c += 1;
 					}
-					if (prop.shorthand) {
+					if (prop.key.type === 'Literal' && !prop.computed) {
+						console.log('' + code)
+						code.overwrite(
+							prop.start,
+							prop.key.end + 1,
+							'[' + code.slice(prop.start, prop.key.end) + '] = '
+						);
+						console.log('' + code)
+					} else if (prop.shorthand) {
 						code.overwrite(
 							prop.start,
 							prop.key.end,

--- a/test/samples/object-properties.js
+++ b/test/samples/object-properties.js
@@ -114,8 +114,20 @@ module.exports = [
 	},
 
 	{
-		description: 'avoids shadowing free variables with method names (#166)',
+		description: 'transpiles string-keyed properties after computed properties',
 
+		input: `
+			fn({['computed']:1, 'some-var':2, a: 3});
+		`,
+		output: `
+			var obj;
+
+			fn(( obj = {}, obj['computed'] = 1, obj['some-var'] = 2, obj.a = 3, obj ));
+		`
+	},
+
+	{
+		description: 'avoids shadowing free variables with method names (#166)',
 		input: `
 			let x = {
 				foo() { return foo },


### PR DESCRIPTION
it currently compiles to 
```js
var obj;
foo(( obj = {}, obj['computed'] = 1, obj.'some-var' = 2, obj ));
```