### PR TITLE
Respect aliased variable names when desctructuring

### DIFF
--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -43,7 +43,7 @@ export default class VariableDeclaration extends Node {
 						declarator.init.type === 'Identifier' && !declarator.init.rewritten;
 
 					const name = simple
-						? declarator.init.name
+						? (declarator.init.alias || declarator.init.name)
 						: declarator.findScope(true).createIdentifier('ref');
 
 					c = declarator.start;

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -858,5 +858,23 @@ module.exports = [
 				var message = ref.message;
 
 			}`
+	},
+
+	{
+		description: 'destructures parameters with same name as function',
+
+		input: `
+			const a = {
+				options (options) {
+					const { input } = options;
+				}
+			}`,
+
+		output: `
+			var a = {
+				options: function options (options$1) {
+					var input = options$1.input;
+				}
+			}`
 	}
 ];


### PR DESCRIPTION
When `declarator.init` is an aliased variable, the alias wasn't looked at when choosing the name for the desctructuring. 