### PR TITLE
Move var declaration to in-place for spread in expressions

### DIFF
--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -57,9 +57,20 @@ export default class CallExpression extends Node {
 					if (this.callee.object.type === 'Identifier') {
 						context = this.callee.object.name;
 					} else {
-						context = this.findScope(true).createDeclaration('ref');
 						const callExpression = this.callee.object;
-						code.prependRight(callExpression.start, `(${context} = `);
+
+						// Prepend the declaraction in place to prevent an expression
+						// begining with a parenthesis. Other types are guarded by
+						// an expression before the parenthesis so the declaration
+						// is created at the top of the scope.
+						if (this.parent.type === 'ExpressionStatement') {
+							context = this.findScope(true).createIdentifier('ref');
+							code.prependRight(callExpression.start, `var ${context}; (${context} = `);
+						} else {
+							context = this.findScope(true).createDeclaration('ref');
+							code.prependRight(callExpression.start, `(${context} = `);
+						}
+
 						code.appendLeft(callExpression.end, `)`);
 					}
 				} else {

--- a/test/samples/spread-operator.js
+++ b/test/samples/spread-operator.js
@@ -38,9 +38,7 @@ module.exports = [
 			( foo || bar ).baz( ...values );`,
 
 		output: `
-			var ref;
-
-			(ref = ( foo || bar )).baz.apply( ref, values );`
+			var ref; (ref = ( foo || bar )).baz.apply( ref, values );`
 	},
 
 	{
@@ -585,5 +583,20 @@ module.exports = [
 						}; }
 			}
 		`
-	}
+	},
+
+	{
+		description:
+			'transpiles a spread operator with semicolon before parens',
+
+		input: `
+			const foo = { bar: [] }
+			const baz = true ? [1,2,3] : []
+			foo.bar.push(...baz)`,
+
+		output: `
+			var foo = { bar: [] }
+			var baz = true ? [1,2,3] : []
+			var ref; (ref = foo.bar).push.apply(ref, baz)`
+	},
 ];


### PR DESCRIPTION
When a spread is in a "naked" expression, the added `(ref` will become a function call of the previous statement, unless a `;` is added before it. This fix moves the declaration of the `ref` variable to immediately before the expression. See the tests for how code is now generated.