### PR TITLE
Support dynamic import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buble",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,10 +9,19 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
       "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "5.2.1"
+      }
+    },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
       "requires": {
         "acorn": "3.3.0"
       },
@@ -20,7 +29,8 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "acorn": "^5.1.2",
+    "acorn-dynamic-import": "^3.0.0",
     "acorn-jsx": "^4.1.1",
     "acorn5-object-spread": "^4.0.0",
     "chalk": "^2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import * as acorn from 'acorn';
 import acornJsx from 'acorn-jsx/inject';
 import acornObjectSpread from 'acorn5-object-spread/inject';
+import acornDynamicImport from 'acorn-dynamic-import/lib/inject';
 import Program from './program/Program.js';
 import { features, matrix } from './support.js';
 import getSnippet from './utils/getSnippet.js';
 
-const { parse } = [acornObjectSpread, acornJsx].reduce(
+const { parse } = [acornObjectSpread, acornJsx, acornDynamicImport].reduce(
 	(final, plugin) => plugin(final),
 	acorn
 );
@@ -68,7 +69,8 @@ export function transform(source, options = {}) {
 			},
 			plugins: {
 				jsx: true,
-				objectSpread: true
+				objectSpread: true,
+				dynamicImport: true
 			}
 		});
 		options.jsx = jsx || options.jsx;

--- a/test/samples/dynamic-import.js
+++ b/test/samples/dynamic-import.js
@@ -1,0 +1,8 @@
+module.exports = [
+	{
+		description: 'support dynamic import',
+		input: `import('./module.js')`,
+		output: `import('./module.js')`
+	}
+
+];


### PR DESCRIPTION
[dynamic import](https://github.com/tc39/proposal-dynamic-import) support has just landed in [Rollup 0.55.0](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#upcoming-0550).
When testing a project that uses buble via rollup-plugin-buble, I noticed that it doesn't support dynamic import yet, resulting in the error

```
SyntaxError: Unexpected token in ...
```

Looking at the [rollup source code](https://github.com/rollup/rollup/blob/089c9e06190b894d766fc44571752fa91dc1eaa5/src/Graph.ts#L3), I see that they are using [acorn-dynamic-import](https://github.com/kesne/acorn-dynamic-import).
This pull request therefore adds the acorn-dynamic-import plugin as done in rollup itself so that buble is able to parse code that uses dynamic import.

I've also created a small test file that fails without these changes.
Let me know if it's enought or if I should write more tests.