### PR TITLE
Fix binary octal num literals

### DIFF
--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -11,8 +11,7 @@ export default class Literal extends Node {
 
 	transpile(code, transforms) {
 		if (transforms.numericLiteral) {
-			const leading = this.raw.slice(0, 2);
-			if (leading === '0b' || leading === '0o') {
+			if (this.raw.match(/^0[bo]/i)) {
 				code.overwrite(this.start, this.end, String(this.value), {
 					storeName: true,
 					contentOnly: true

--- a/test/samples/binary-and-octal.js
+++ b/test/samples/binary-and-octal.js
@@ -3,11 +3,13 @@ module.exports = [
 		description: 'transpiles binary numbers',
 
 		input: `
-			var num = 0b111110111;
+			var num1 = 0b111110111;
+			var num2 = 0B111110111;
 			var str = '0b111110111';`,
 
 		output: `
-			var num = 503;
+			var num1 = 503;
+			var num2 = 503;
 			var str = '0b111110111';`
 	},
 
@@ -15,11 +17,13 @@ module.exports = [
 		description: 'transpiles octal numbers',
 
 		input: `
-			var num = 0o767;
+			var num1 = 0o767;
+			var num2 = 0O767;
 			var str = '0o767';`,
 
 		output: `
-			var num = 503;
+			var num1 = 503;
+			var num2 = 503;
 			var str = '0o767';`
 	},
 


### PR DESCRIPTION
Fix #74, binary and octal number literals are now properly transpired regardless uppercase or downcase base prefix