### PR TITLE
fix: move regexpu-core out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint": "^4.17.0",
     "glob": "^7.0.3",
     "mocha": "^5.0.0",
-    "regexpu-core": "^4.1.3",
     "rimraf": "^2.5.2",
     "rollup": "^0.55.5",
     "rollup-plugin-buble": "^0.19.1",
@@ -69,6 +68,7 @@
     "magic-string": "^0.22.4",
     "minimist": "^1.2.0",
     "os-homedir": "^1.0.1",
+    "regexpu-core": "^4.1.3",
     "vlq": "^1.0.0"
   }
 }


### PR DESCRIPTION
Used here:
https://github.com/Rich-Harris/buble/blob/master/src/program/types/Literal.js#L3