### PR TITLE
extract createConfig() to another file to be reused

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,43 +1,5 @@
-import buble from 'rollup-plugin-buble';
-import json from 'rollup-plugin-json';
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
+import createConfig from './rollup.create-config';
 import pkg from './package.json';
-
-const ensureArray = maybeArr => Array.isArray(maybeArr) ? maybeArr : [maybeArr];
-
-const createConfig = (opts) => {
-	opts = opts || {};
-	const browser = opts.browser || false;
-	const external = opts.external || ['acorn', 'magic-string'];
-	const output = ensureArray(opts.output);
-
-	return {
-		input: 'src/index.js',
-		output: output.map(format => Object.assign({}, format, {
-			name: 'buble',
-			sourcemap: true
-		})),
-		external: external,
-		plugins: [
-			json(),
-			commonjs(),
-			buble({
-				target: !browser ? { node: 4 } : null,
-				include: [
-					'src/**',
-					'node_modules/regexpu-core/**',
-					'node_modules/unicode-match-property-ecmascript/**',
-					'node_modules/unicode-match-property-value-ecmascript/**',
-				],
-				transforms: {
-					dangerousForOf: true
-				}
-			}),
-			resolve()
-		],
-	};
-};
 
 const configs = [
 	/* node ESM/CJS builds */

--- a/rollup.create-config.js
+++ b/rollup.create-config.js
@@ -1,0 +1,41 @@
+import buble from 'rollup-plugin-buble';
+import json from 'rollup-plugin-json';
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+const ensureArray = maybeArr => Array.isArray(maybeArr) ? maybeArr : [maybeArr];
+
+const createConfig = (opts) => {
+	opts = opts || {};
+	const browser = opts.browser || false;
+	const external = opts.external || ['acorn', 'magic-string'];
+	const output = ensureArray(opts.output);
+
+	return {
+		input: 'src/index.js',
+		output: output.map(format => Object.assign({}, format, {
+			name: 'buble',
+			sourcemap: true
+		})),
+		external: external,
+		plugins: [
+			json(),
+			commonjs(),
+			buble({
+				target: !browser ? { node: 4 } : null,
+				include: [
+					'src/**',
+					'node_modules/regexpu-core/**',
+					'node_modules/unicode-match-property-ecmascript/**',
+					'node_modules/unicode-match-property-value-ecmascript/**',
+				],
+				transforms: {
+					dangerousForOf: true
+				}
+			}),
+			resolve()
+		],
+	};
+};
+
+export default createConfig;


### PR DESCRIPTION
Hello!

First of all, thanks for your awesome and incredible work. 🎉

In my use case, I need to create a custom bundle of buble for the browser. I would really like to avoid two things:

1. Having to mantain a fork of this repo
2. Having to copy `rollup.config.js` and modify it each time.

I want to re-use the function createConfig(), which has all the absolutely needed information, and then customize my config to create the bundle the way I need it. I don't want to pollute this repo with my specific bundle options, I want to enable anyone to easily create custom builds of Buble.

Thank you again.