### PR TITLE
Make sure closing parens and braces are added in the right order

### DIFF
--- a/src/program/types/AssignmentExpression.js
+++ b/src/program/types/AssignmentExpression.js
@@ -69,7 +69,7 @@ export default class AssignmentExpression extends Node {
 
 		if (this.unparenthesizedParent().type === 'ExpressionStatement') {
 			// no rvalue needed for expression statement
-			code.appendRight(this.end, `)`);
+			code.prependRight(this.end, `)`);
 		} else {
 			// destructuring is part of an expression - need an rvalue
 			code.appendRight(this.end, `, ${assign})`);

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -876,5 +876,17 @@ module.exports = [
 					var input = options$1.input;
 				}
 			}`
+	},
+
+	{
+		description: 'destructuring inside a brace-less if',
+
+		input: `
+			if (from) [from, to] = [to, from]`,
+
+		output: `
+			var assign;
+
+			if (from) { (assign = [to, from], from = assign[0], to = assign[1]) }`
 	}
 ];


### PR DESCRIPTION
See issue #152

Before, the if a destructuring assignment expression was wrapped in parens, but also wrapped in braces because it was a brace-less `if` statement's body, the closing brace would end up before the closing parenthesis.

On the whole, magic-string seems to be scarily fragile for stuff like this, but this fix seems to address the problem.