### PR TITLE
should not break on a global return

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ export function transform(source, options = {}) {
 			ecmaVersion: 10,
 			preserveParens: true,
 			sourceType: 'module',
+			allowReturnOutsideFunction: true,
 			onComment: (block, text) => {
 				if (!jsx) {
 					let match = /@jsx\s+([^\s]+)/.exec(text);


### PR DESCRIPTION
Added the 'allowReturnOutsideFunction: true' flag.

transform(.., options) should pass acorn options, if a developer wants something specific.
Even though this goes against your 'zero config' policy, it will let users change conf without a pool request.

Please push to NPM asap, I want to use it in my code. 😄 