### PR TITLE
Treat all dependencies as externals

### DIFF
--- a/rollup.create-config.js
+++ b/rollup.create-config.js
@@ -2,13 +2,14 @@ import buble from 'rollup-plugin-buble';
 import json from 'rollup-plugin-json';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import pkg from './package.json';
 
 const ensureArray = maybeArr => Array.isArray(maybeArr) ? maybeArr : [maybeArr];
 
 const createConfig = (opts) => {
 	opts = opts || {};
 	const browser = opts.browser || false;
-	const external = opts.external || ['acorn', 'magic-string'];
+	const external = opts.external || Object.keys(pkg.dependencies || {});
 	const output = ensureArray(opts.output);
 
 	return {


### PR DESCRIPTION
As explained in https://github.com/Rich-Harris/buble/issues/159#issuecomment-430633708 rollup doesn't like half-internalized externals. This change will treat all dependencies as externals and thus won't try to convert their imports.

Fixes #158 
Fixes #159 
Replaces #160