### PR TITLE
Add .gitattributes to prevent test/lint failures in some envs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
After an initial clone, due to my global git settings, npm install showed failing tests that were all related to a comparisons with line endings of \n failing.

Adding a .gitattributes allows git glone in windows to preserve the line endings correctly allowing the unit tests to pass - regardless of a users global git config.