### PR TITLE
Parenthesize a first spread element when necessary

### DIFF
--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import spread, { isArguments, inlineSpreads } from '../../utils/spread.js';
+import spread, { isArguments, inlineSpreads, needsParentheses } from '../../utils/spread.js';
 import removeTrailingComma from '../../utils/removeTrailingComma.js';
 
 export default class CallExpression extends Node {
@@ -77,7 +77,11 @@ export default class CallExpression extends Node {
 					_super.noCall = true; // bit hacky...
 
 					if (this.arguments.length > 1) {
-						if (firstArgument.type !== 'SpreadElement') {
+						if (firstArgument.type === 'SpreadElement') {
+							if (needsParentheses(firstArgument.argument)) {
+								code.prependRight(firstArgument.start, `( `);
+							}
+						} else {
 							code.prependRight(firstArgument.start, `[ `);
 						}
 
@@ -90,7 +94,11 @@ export default class CallExpression extends Node {
 					code.prependRight(firstArgument.start, `${context}, `);
 				} else {
 					if (firstArgument.type === 'SpreadElement') {
-						code.appendLeft(firstArgument.start, `${context}, `);
+						if (needsParentheses(firstArgument.argument)) {
+							code.appendLeft(firstArgument.start, `${context}, ( `);
+						} else {
+							code.appendLeft(firstArgument.start, `${context}, `);
+						}
 					} else {
 						code.appendLeft(firstArgument.start, `${context}, [ `);
 					}

--- a/test/samples/spread-operator.js
+++ b/test/samples/spread-operator.js
@@ -882,4 +882,12 @@ module.exports = [
 			new f(w, x, y, z);
 		`
 	},
+
+	{
+		description: 'transpiles a first spread element comprising a ternary operator',
+
+		input: '[...a ? b : c, d]',
+
+		output: '( a ? b : c ).concat( [d])',
+	}
 ];


### PR DESCRIPTION
In most cases this is unnecessary, but for some expression types it is necessary, notably in ternaries; for `a ? b : c.concat(…)` is very different from `(a ? b : c).concat(…)`.

I’m not clear why the insertion of the opening parenthesis had to happen in src/program/types/CallExpression.js rather than src/utils/spread.js when start === element.start; but if I did it inside spread(), if I used appendLeft or prependLeft it’d end up like `.apply((Math, a).concat(…))` instead of `.apply(Math, (a).concat(…))`, and if I used appendRight or prependRight, nothing happened.

Fixes #177.