### PR TITLE
Inline spread elements where possible

### DIFF
--- a/src/program/types/ArrayExpression.js
+++ b/src/program/types/ArrayExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import spread, { isArguments } from '../../utils/spread.js';
+import spread, { isArguments, inlineSpreads } from '../../utils/spread.js';
 
 export default class ArrayExpression extends Node {
 	initialise(transforms) {
@@ -26,6 +26,7 @@ export default class ArrayExpression extends Node {
 		super.transpile(code, transforms);
 
 		if (transforms.spreadRest) {
+			inlineSpreads(code, this, this.elements);
 			// erase trailing comma after last array element if not an array hole
 			if (this.elements.length) {
 				const lastElement = this.elements[this.elements.length - 1];

--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import spread, { isArguments } from '../../utils/spread.js';
+import spread, { isArguments, inlineSpreads } from '../../utils/spread.js';
 import removeTrailingComma from '../../utils/removeTrailingComma.js';
 
 export default class CallExpression extends Node {
@@ -20,6 +20,11 @@ export default class CallExpression extends Node {
 	}
 
 	transpile(code, transforms) {
+		if (transforms.spreadRest && this.arguments.length) {
+			inlineSpreads(code, this, this.arguments);
+			// this.arguments.length may have changed, must retest.
+		}
+
 		if (transforms.spreadRest && this.arguments.length) {
 			let hasSpreadElements = false;
 			let context;

--- a/src/program/types/NewExpression.js
+++ b/src/program/types/NewExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import spread, { isArguments } from '../../utils/spread.js';
+import spread, { isArguments, inlineSpreads } from '../../utils/spread.js';
 import removeTrailingComma from '../../utils/removeTrailingComma.js';
 
 export default class NewExpression extends Node {
@@ -22,6 +22,11 @@ export default class NewExpression extends Node {
 
 	transpile(code, transforms) {
 		super.transpile(code, transforms);
+
+		if (transforms.spreadRest && this.arguments.length) {
+			inlineSpreads(code, this, this.arguments);
+			// this.arguments.length may have changed, must retest.
+		}
 
 		if (transforms.spreadRest && this.arguments.length) {
 			const firstArgument = this.arguments[0];

--- a/test/samples/computed-properties.js
+++ b/test/samples/computed-properties.js
@@ -238,7 +238,7 @@ module.exports = [
 			let a = {
 				[foo] (x, y) {
 					return {
-						...{abc: '123'}
+						...c
 					};
 				},
 			};
@@ -246,7 +246,7 @@ module.exports = [
 		output: `
 			var a = {};
 			a[foo] = function (x, y) {
-					return Object.assign({}, {abc: '123'});
+					return Object.assign({}, c);
 				};
 		`
 	},

--- a/test/samples/object-rest-spread.js
+++ b/test/samples/object-rest-spread.js
@@ -277,6 +277,61 @@ for( var a = c.a, rest = objectWithoutProperties( c, ["a"] ), b = rest;; ) {}`
 	input: `for( var {...b} = c;; ) {}`,
 	output: `function objectWithoutProperties (obj, exclude) { var target = {}; for (var k in obj) if (Object.prototype.hasOwnProperty.call(obj, k) && exclude.indexOf(k) === -1) target[k] = obj[k]; return target; }
 for( var rest = objectWithoutProperties( c, [] ), b = rest;; ) {}`
-	}
+	},
 
+	{
+		description: 'inlines object spread with one object',
+		input: `var obj = {...{a: 1}};`,
+		output: `var obj = {a: 1};`
+	},
+
+	{
+		description: 'inlines object spread with two objects',
+		input: `var obj = {...{a: 1}, ...{b: 2}};`,
+		output: `var obj = {a: 1, b: 2};`
+	},
+
+	{
+		description: 'inlines object spread with regular keys in between',
+		input: `var obj = { ...{a: 1}, b: 2, c: 3 };`,
+		output: `var obj = { a: 1, b: 2, c: 3 };`
+	},
+
+	{
+		description: 'inlines object spread mixed',
+		input: `var obj = { ...{a: 1}, b: 2, ...{c: 3}, e};`,
+		output: `var obj = { a: 1, b: 2, c: 3, e: e};`
+	},
+
+	{
+		description: 'inlines object spread very mixed',
+		options: {
+			objectAssign: 'Object.assign'
+		},
+		input: `var obj = { ...{a: 1}, b: 2, ...c, e};`,
+		output: `var obj = Object.assign({}, {a: 1, b: 2}, c, {e: e});`
+	},
+
+	{
+		description: 'inlines object spread without extraneous trailing commas',
+		options: {
+			objectAssign: 'Object.assign'
+		},
+		input: `
+			var obj = { ...{a: 1,}, b: 2, ...{c: 3,}, ...d, e, ...{f: 6,},};
+			obj = { a: 1, b: 2, };
+			obj = { a: 1, ...{b: 2} };
+			obj = { a: 1, ...{b: 2,} };
+			obj = { a: 1, ...{b: 2}, };
+			obj = { a: 1, ...{b: 2,}, };
+		`,
+		output: `
+			var obj = Object.assign({}, {a: 1, b: 2, c: 3}, d, {e: e, f: 6});
+			obj = { a: 1, b: 2, };
+			obj = { a: 1, b: 2 };
+			obj = { a: 1, b: 2 };
+			obj = { a: 1, b: 2, };
+			obj = { a: 1, b: 2, };
+		`
+	}
 ];


### PR DESCRIPTION
My use case that leads me to desire this is code conditional on compile-time constants, e.g. `{ …, ...FEATURE ? { … } : { … } }` (with Rollup’s tree-shaking resolving the FEATURE ternary before it gets to Bublé). I first implemented what amounts to this change in Terser (https://github.com/terser-js/terser/pull/224), but then realised that I was running Bublé before Terser, and so Terser never actually *got* the spreads to inline. The next idea was running Terser, then Bublé, then Terser again… yuck. Then I decided that this optimisation really belonged in Bublé anyway: generating less code is good!

Implementation notes:

The ObjectExpression implementation was straightforward and I implemented it in situ.

Then the ArrayExpression, CallExpression and NewExpression one: at first I performed the spread inlining in spread()’s while loop, and that seemed to work well, but I got scared of how ArrayExpression and CallExpression both handled their “single element” cases specially, and that they did not appear to be optional inasmuch as removing the special-casing yielded exceptions in the test suite; so I extracted that
into a separate function. That ended up pleasing me more as well, with clearly cut semantics and a smaller diff inside the *Expression files, as they no longer needed to change their single-element special cases to *not* activate on a SpreadElement containing an ArrayElement.