### PR TITLE
Bump magic-string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,7 @@
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
-        "magic-string": "0.25.1",
+        "magic-string": "0.25.2",
         "minimist": "1.2.0",
         "os-homedir": "1.0.2",
         "regexpu-core": "4.4.0",
@@ -1020,11 +1020,11 @@
       }
     },
     "magic-string": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
       "requires": {
-        "sourcemap-codec": "1.4.3"
+        "sourcemap-codec": "1.4.4"
       }
     },
     "math-random": {
@@ -1647,9 +1647,9 @@
       }
     },
     "sourcemap-codec": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
-      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "acorn-dynamic-import": "^4.0.0",
     "acorn-jsx": "^5.0.1",
     "chalk": "^2.4.2",
-    "magic-string": "^0.25.1",
+    "magic-string": "^0.25.2",
     "minimist": "^1.2.0",
     "os-homedir": "^1.0.1",
     "regexpu-core": "^4.4.0"


### PR DESCRIPTION
Closes #183 

Care was taken to use versions of Node and NPM as discussed in https://github.com/Rich-Harris/buble/pull/184 for generating minimal changes to `package-lock.json`.

```
$ node --version
v10.15.1
$ npm --version
5.8.0
```