### PR TITLE
fix: returning from nested loop only exits function if return value is truthy

### DIFF
--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -91,7 +91,7 @@ export default class LoopStatement extends Node {
 				if (this.canBreak)
 					insert += `\n${i1}if ( ${returned} === 'break' ) break;`;
 				if (this.canReturn)
-					insert += `\n${i1}if ( ${returned} ) return ${returned}.v;`;
+					insert += `\n${i1}if ( typeof ${returned} !== void 0 ) return ${returned}.v;`;
 				insert += `\n${i0}}`;
 
 				code.prependRight(this.body.end, insert);


### PR DESCRIPTION
Normally, if a function contains an inner loop and an outer loop, a return statement will exit the whole function.

Since buble transforms loops into functions, in order to preserve this behaviour there is a test for whether there is a returned value from the inner loop, and if so, we break out of the outer loop as well.

However, the test for whether there is a returned value is whether the return value is truthy. So if you return false, or undefined or zero, the outer loop will continue, causing some very had to diagnose and unintuitive bugs, especially when hidden away by sourcemaps.

This PR improves on the current implementation by testing whether the return value is defined. It isn't a perfect solution since you could have a return statement with no return value, and that would also fail to exit the function. However, I don't really understand the codebase enough yet to suggest a better solution and this is probably better than nothing.